### PR TITLE
How to navigate to error cells in WPF and UWP DataGrid (SfDataGrid) via button click

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 This example explains about how to navigate to error cells in [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid) via button click.
 
 [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid) does not have support to navigate through the error cells specifically. You can navigate to the error cells using the [CurrentRowColumnIndex](http://help.syncfusion.com/cr/cref_files/wpf/Syncfusion.SfGrid.WPF~Syncfusion.UI.Xaml.Grid.GridCurrentCellManager~CurrentRowColumnIndex.html) and [GridCell.HasError](http://help.syncfusion.com/cr/cref_files/wpf/Syncfusion.SfGrid.WPF~Syncfusion.UI.Xaml.Grid.GridCell~HasError.html) properties through button click.
+
+KB article - [How to navigate to error cells in WPF and UWP DataGrid (SfDataGrid) via button click?](https://www.syncfusion.com/kb/9600/how-to-navigate-to-the-error-cells-in-wpf-datagrid-sfdatagrid-via-button-click)


### PR DESCRIPTION
documentation(DOC-3343): KB link